### PR TITLE
feat: implement HoldMode for failsafe fallback

### DIFF
--- a/crates/core/src/mode/hold.rs
+++ b/crates/core/src/mode/hold.rs
@@ -1,0 +1,155 @@
+//! Hold Mode
+//!
+//! Simplest control mode: zeros all actuator outputs unconditionally.
+//! Serves as the primary failsafe fallback mode.
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use crate::servo::ActuatorInterface;
+
+use super::traits::Mode;
+
+/// Hold Mode
+///
+/// Zeros all actuator outputs on enter, every update, and exit.
+/// Has no external dependencies and always succeeds entry.
+pub struct HoldMode {
+    actuators: Box<dyn ActuatorInterface>,
+}
+
+impl HoldMode {
+    /// Create new Hold mode
+    ///
+    /// # Arguments
+    ///
+    /// * `actuators` - Actuator interface for steering and throttle
+    pub fn new(actuators: Box<dyn ActuatorInterface>) -> Self {
+        Self { actuators }
+    }
+}
+
+impl Mode for HoldMode {
+    fn enter(&mut self) -> Result<(), &'static str> {
+        crate::log_info!("Entering Hold mode");
+        self.actuators.set_steering(0.0)?;
+        self.actuators.set_throttle(0.0)?;
+        Ok(())
+    }
+
+    fn update(&mut self, _dt: f32) -> Result<(), &'static str> {
+        self.actuators.set_steering(0.0)?;
+        self.actuators.set_throttle(0.0)?;
+        Ok(())
+    }
+
+    fn exit(&mut self) -> Result<(), &'static str> {
+        crate::log_info!("Exiting Hold mode");
+        self.actuators.set_steering(0.0)?;
+        self.actuators.set_throttle(0.0)?;
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "Hold"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use super::*;
+
+    struct MockActuator {
+        steering: f32,
+        throttle: f32,
+    }
+
+    impl MockActuator {
+        fn new() -> Self {
+            Self {
+                steering: 0.0,
+                throttle: 0.0,
+            }
+        }
+    }
+
+    impl ActuatorInterface for MockActuator {
+        fn set_steering(&mut self, normalized: f32) -> Result<(), &'static str> {
+            self.steering = normalized;
+            Ok(())
+        }
+        fn set_throttle(&mut self, normalized: f32) -> Result<(), &'static str> {
+            self.throttle = normalized;
+            Ok(())
+        }
+        fn get_steering(&self) -> f32 {
+            self.steering
+        }
+        fn get_throttle(&self) -> f32 {
+            self.throttle
+        }
+    }
+
+    #[test]
+    fn test_hold_mode_enter_exit() {
+        let mut mode = HoldMode::new(Box::new(MockActuator::new()));
+
+        assert!(mode.enter().is_ok());
+        assert!(
+            mode.actuators.get_steering().abs() < 0.001,
+            "Enter should zero steering"
+        );
+        assert!(
+            mode.actuators.get_throttle().abs() < 0.001,
+            "Enter should zero throttle"
+        );
+
+        assert!(mode.exit().is_ok());
+        assert!(
+            mode.actuators.get_steering().abs() < 0.001,
+            "Exit should zero steering"
+        );
+        assert!(
+            mode.actuators.get_throttle().abs() < 0.001,
+            "Exit should zero throttle"
+        );
+    }
+
+    #[test]
+    fn test_hold_mode_update_zeros_actuators() {
+        let mut mock = MockActuator::new();
+        mock.steering = 0.5;
+        mock.throttle = 0.8;
+        let mut mode = HoldMode::new(Box::new(mock));
+
+        mode.update(0.02).unwrap();
+
+        assert!(
+            mode.actuators.get_steering().abs() < 0.001,
+            "Update should zero steering, got {}",
+            mode.actuators.get_steering()
+        );
+        assert!(
+            mode.actuators.get_throttle().abs() < 0.001,
+            "Update should zero throttle, got {}",
+            mode.actuators.get_throttle()
+        );
+    }
+
+    #[test]
+    fn test_hold_mode_name() {
+        let mode = HoldMode::new(Box::new(MockActuator::new()));
+        assert_eq!(mode.name(), "Hold");
+    }
+
+    #[test]
+    fn test_hold_mode_size() {
+        assert!(
+            core::mem::size_of::<HoldMode>() <= 32,
+            "HoldMode should be <= 32 bytes, got {}",
+            core::mem::size_of::<HoldMode>()
+        );
+    }
+}

--- a/crates/core/src/mode/mod.rs
+++ b/crates/core/src/mode/mod.rs
@@ -23,6 +23,7 @@ mod traits;
 
 // Mode implementations (no embassy dependency)
 pub mod circle;
+pub mod hold;
 pub mod loiter;
 pub mod rtl;
 pub mod smartrtl;
@@ -43,6 +44,7 @@ pub use traits::Mode;
 
 // Re-export mode types (non-embassy)
 pub use circle::{CircleConfig, CircleMode};
+pub use hold::HoldMode;
 pub use loiter::{LoiterState, RoverLoiter};
 pub use rtl::RtlMode;
 pub use smartrtl::SmartRtlMode;

--- a/docs/analysis/AN-00167-hold-mode.md
+++ b/docs/analysis/AN-00167-hold-mode.md
@@ -1,0 +1,390 @@
+# AN-00167 Hold Mode
+
+## Metadata
+
+- Type: Analysis
+- Status: Approved
+
+## Links
+
+- Related Analyses:
+  - [AN-00012-mode-capability-system](AN-00012-mode-capability-system.md)
+  - [AN-00013-mode-entry-validation](AN-00013-mode-entry-validation.md)
+  - [AN-00014-mode-lifecycle-management](AN-00014-mode-lifecycle-management.md)
+  - [AN-00011-failsafe-system](AN-00011-failsafe-system.md)
+- Related Requirements:
+  - [FR-00168-hold-mode-actuator-stop](../requirements/FR-00168-hold-mode-actuator-stop.md)
+  - [FR-00169-hold-mode-identity](../requirements/FR-00169-hold-mode-identity.md)
+  - [NFR-00170-hold-mode-performance](../requirements/NFR-00170-hold-mode-performance.md)
+- Related ADRs: N/A – straightforward implementation, no architectural decision needed
+- Related Tasks:
+  - [T-00171-hold-mode](../tasks/T-00171-hold-mode/README.md)
+
+## Executive Summary
+
+This analysis examines the implementation of Hold mode as a `Mode` trait implementation struct. The `FlightMode::Hold` enum variant already exists in the codebase and is used by the battery failsafe system, motor control runner, and MAVLink state reporting (custom mode number 4). However, no `HoldMode` struct implementing the `Mode` trait exists, meaning Hold mode cannot be selected via `ModeExecutor::set_mode()`.
+
+Hold mode is the simplest possible mode: zero all actuator outputs and remain stationary. It requires no GPS, no navigation controller, and no RC input. This makes it the ideal failsafe fallback for situations where other modes cannot be entered.
+
+## Problem Space
+
+### Current State
+
+**FlightMode::Hold enum variant:**
+
+- Defined in `crates/core/src/autopilot/state.rs` with custom mode number 4
+- Referenced by `MotorControlRunner::step()` which returns zero motor output with `should_stop: true`
+- Used as battery failsafe target (`BatteryFailsafeAction::Hold`)
+- Mapped in MAVLink `to_custom_mode()` / `from_custom_mode()` conversions
+- GCS can request Hold mode via `SET_MODE` command
+
+**Missing `HoldMode` struct:**
+
+- No `crates/core/src/mode/hold.rs` file exists
+- No struct implementing `Mode` trait for Hold behavior
+- Cannot be instantiated via `ModeExecutor::set_mode(Box::new(HoldMode::new(...)))`
+
+**Existing mode implementations for reference:**
+
+- `ManualMode` in `crates/core/src/mode/manual.rs` — simplest existing mode (RC passthrough)
+- All modes implement `Mode` trait with `enter()`, `update()`, `exit()`, `name()` methods
+- Modes take `Box<dyn ActuatorInterface>` for actuator control
+
+**Where Hold is used today (without a Mode implementation):**
+
+- `MotorControlRunner::step()` short-circuits to zero output for `FlightMode::Hold`
+- Battery failsafe sets `FlightMode::Hold` directly in `SystemState`
+- SITL `execute_mode()` falls through to ModeExecutor for non-Guided/Auto modes
+
+### Desired State
+
+A `HoldMode` struct that:
+
+- Implements the `Mode` trait
+- Zeros all actuator outputs on `enter()` and `update()`
+- Can be instantiated and passed to `ModeExecutor::set_mode()`
+- Serves as the reliable fallback mode when other modes fail to enter
+- Works without GPS, RC input, or any external dependencies
+
+### Gap Analysis
+
+| Component                | Current State                         | Desired State                      | Gap         |
+| ------------------------ | ------------------------------------- | ---------------------------------- | ----------- |
+| `FlightMode::Hold` enum  | Exists (custom mode 4)                | No change needed                   | None        |
+| `HoldMode` struct        | Does not exist                        | `Mode` trait implementation        | New file    |
+| Motor control            | `MotorControlRunner` handles Hold     | No change needed                   | None        |
+| ModeExecutor integration | Cannot create `HoldMode` instance     | Instantiable via `HoldMode::new()` | Constructor |
+| Failsafe fallback        | Sets `FlightMode::Hold` in state only | Also transition `ModeExecutor`     | Integration |
+| SITL mode dispatch       | Falls to ModeExecutor wildcard        | No change needed                   | None        |
+
+## Stakeholder Analysis
+
+| Stakeholder     | Interest/Need                              | Impact | Priority |
+| --------------- | ------------------------------------------ | ------ | -------- |
+| Failsafe System | Reliable fallback mode for battery/RC loss | High   | P0       |
+| Field Operators | Safe stop without switching to Manual      | High   | P0       |
+| GCS Users       | Standard ArduPilot Hold mode via SET_MODE  | Medium | P1       |
+| Arming System   | Safe mode during arm/disarm procedures     | Medium | P1       |
+
+## Research & Discovery
+
+### User Feedback
+
+N/A — Derived from ArduPilot standard functionality and feature backlog (FB-016).
+
+### Competitive Analysis
+
+**ArduPilot Hold Mode (Rover):**
+
+From official documentation:
+
+- Vehicle stops all movement
+- Steering outputs are set to SERVOx_TRIM values (neutral)
+- Motor outputs are set to SERVOx_TRIM values (zero throttle)
+- No GPS required
+- No active position correction (contrast with Loiter)
+- Primary use cases: arming/disarming safely, failsafe destination
+- ArduPilot custom mode number: 4
+
+**Key Behavioral Properties:**
+
+| Property                   | Value                            |
+| -------------------------- | -------------------------------- |
+| GPS required               | No                               |
+| RC input required          | No                               |
+| Active position correction | No                               |
+| Actuator state             | Neutral (steering=0, throttle=0) |
+| Entry conditions           | Always succeeds                  |
+| ArduPilot mode number      | 4                                |
+
+**Difference from Related Modes:**
+
+| Aspect               | Hold Mode               | Manual Mode     | Loiter Mode        |
+| -------------------- | ----------------------- | --------------- | ------------------ |
+| Motor output         | Always zero             | RC passthrough  | Zero or correction |
+| GPS requirement      | None                    | None            | Required           |
+| RC requirement       | None                    | Required        | None               |
+| Position holding     | Passive (no correction) | N/A             | Active (Type 1)    |
+| Complexity           | Minimal                 | Low             | Medium             |
+| Failsafe suitability | Excellent               | Poor (needs RC) | Requires GPS       |
+
+### Technical Investigation
+
+#### HoldMode Structure
+
+Hold mode is architecturally identical to the simplest case: zero all outputs on every cycle.
+
+```rust
+pub struct HoldMode {
+    actuators: Box<dyn ActuatorInterface>,
+}
+```
+
+**Why this is so simple:**
+
+1. No state machine needed — always in the same state (stopped)
+2. No external data dependencies — no GPS, no RC, no navigation
+3. No parameters — no `HOLD_*` ArduPilot parameters exist
+4. `enter()` always succeeds — no preconditions to validate
+5. `update()` is trivially zero output — idempotent
+6. `exit()` is also zero output — same as update
+
+#### Integration Points
+
+**1. ModeExecutor (mode transition):**
+
+```rust
+// Creating and switching to Hold mode
+let hold = Box::new(HoldMode::new(actuators));
+mode_executor.set_mode(hold)?;
+```
+
+**2. MotorControlRunner (already handled):**
+
+The `MotorControlRunner::step()` already returns zero output for `FlightMode::Hold`. The `HoldMode::update()` will also set actuators to zero, providing defense-in-depth.
+
+**3. Battery Failsafe:**
+
+Currently sets `FlightMode::Hold` in `SystemState`. The `HoldMode` struct enables proper mode transition via `ModeExecutor::set_mode()` in addition to the state flag.
+
+**4. SITL `execute_mode()`:**
+
+Hold falls into the wildcard `_ =>` arm which runs `ModeExecutor`. Once `HoldMode` is set as the active mode, the executor will call `HoldMode::update()`.
+
+### Data Analysis
+
+**Memory Requirements:**
+
+| Component         | Size  | Notes                                          |
+| ----------------- | ----- | ---------------------------------------------- |
+| `HoldMode` struct | \~16B | One `Box<dyn ActuatorInterface>` (fat pointer) |
+| Total             | \~16B | Smallest possible mode                         |
+
+**CPU Requirements:**
+
+| Operation  | Cost                | Notes                      |
+| ---------- | ------------------- | -------------------------- |
+| `enter()`  | \~2 actuator writes | Set steering=0, throttle=0 |
+| `update()` | \~2 actuator writes | Set steering=0, throttle=0 |
+| `exit()`   | \~2 actuator writes | Set steering=0, throttle=0 |
+
+## Discovered Requirements
+
+### Functional Requirements
+
+- [x] **FR-00168-hold-mode-actuator-stop**: System shall provide a Hold mode that stops all actuator output
+  - See: [FR-00168-hold-mode-actuator-stop](../requirements/FR-00168-hold-mode-actuator-stop.md)
+
+- [x] **FR-00169-hold-mode-identity**: Hold mode shall report its identity as "Hold" for telemetry and logging
+  - See: [FR-00169-hold-mode-identity](../requirements/FR-00169-hold-mode-identity.md)
+
+### Non-Functional Requirements
+
+- [x] **NFR-00170-hold-mode-performance**: Hold mode shall use minimal memory and execute in constant time
+  - See: [NFR-00170-hold-mode-performance](../requirements/NFR-00170-hold-mode-performance.md)
+
+## Design Considerations
+
+### Technical Constraints
+
+**Existing Architecture:**
+
+- Mode trait interface: `enter()`, `update(dt)`, `exit()`, `name()`
+- `ActuatorInterface` with `set_steering()` and `set_throttle()`
+- `ModeExecutor` manages mode lifecycle with `Box<dyn Mode>`
+- All modes live in `crates/core/src/mode/`
+
+**No Parameters Needed:**
+
+ArduPilot's Hold mode has no dedicated parameters. The behavior is fixed: zero all outputs. This aligns with the project's principle of following ArduPilot parameter standards — no custom parameters should be created for Hold mode.
+
+**No `can_enter()` Needed:**
+
+Unlike `AutoMode::can_enter()` or `GuidedMode::can_enter()` which validate GPS, Hold mode has no preconditions. The `enter()` method always succeeds, making a separate `can_enter()` validation unnecessary.
+
+### Potential Approaches
+
+#### Approach A: Standalone HoldMode Struct (Recommended)
+
+**Description:** Create a minimal `HoldMode` struct with `ActuatorInterface` dependency, following the same pattern as `ManualMode`.
+
+**Pros:**
+
+- Consistent with existing mode patterns
+- Clear, self-contained implementation
+- Easy to test in isolation
+- Works as ModeExecutor-managed mode
+
+**Cons:**
+
+- None significant
+
+**Effort:** Very Low (< 1 hour)
+
+#### Approach B: Shared NullMode / StoppedMode Generic
+
+**Description:** Create a generic "stopped" mode that could be reused for any mode needing zero output.
+
+**Pros:**
+
+- Could share code with initial state of other modes
+
+**Cons:**
+
+- Over-engineering for a trivial implementation
+- Each mode has unique lifecycle needs
+- Adds unnecessary abstraction
+
+**Effort:** Low
+
+### Architecture Impact
+
+**New Components:**
+
+- `crates/core/src/mode/hold.rs`: HoldMode implementation (\~50 lines)
+
+**Modified Components:**
+
+- `crates/core/src/mode/mod.rs`: Add `pub mod hold;` and re-export `HoldMode`
+
+**No Impact On:**
+
+- `FlightMode` enum (already has `Hold` variant)
+- `MotorControlRunner` (already handles `FlightMode::Hold`)
+- MAVLink state mapping (already has custom mode 4)
+- Parameters (no Hold-specific parameters)
+
+## Risk Assessment
+
+| Risk                                         | Probability | Impact | Mitigation Strategy                           |
+| -------------------------------------------- | ----------- | ------ | --------------------------------------------- |
+| Actuator writes fail silently                | Very Low    | Low    | Log errors from `set_steering`/`set_throttle` |
+| Conflict with MotorControlRunner zero output | Very Low    | None   | Both produce same result (defense-in-depth)   |
+
+## Open Questions
+
+- [x] Does ArduPilot Hold mode have any parameters? → No, behavior is fixed
+- [x] Should Hold mode require GPS? → No, it must work without any sensors
+- [x] Is an ADR needed? → No, this is a straightforward implementation following existing patterns
+- [x] Should `can_enter()` be implemented? → No, Hold mode has no preconditions
+
+## Recommendations
+
+### Immediate Actions
+
+1. **Create `HoldMode` struct:**
+   - New file: `crates/core/src/mode/hold.rs`
+   - Implement `Mode` trait: zero actuators on enter/update/exit
+   - Constructor: `HoldMode::new(actuators: Box<dyn ActuatorInterface>)`
+
+2. **Register module:**
+   - Add `pub mod hold;` to `crates/core/src/mode/mod.rs`
+   - Re-export `HoldMode` from the module
+
+3. **Add unit tests:**
+   - Test enter always succeeds
+   - Test update zeros actuators
+   - Test exit zeros actuators
+   - Test name returns "Hold"
+
+### Next Steps
+
+1. [x] Create formal requirements after analysis approval
+   - Created: FR-00168, FR-00169, NFR-00170
+2. [x] Create task package with design and plan
+   - Created: [T-00171-hold-mode](../tasks/T-00171-hold-mode/README.md)
+3. [x] Implement HoldMode (single phase, very small scope)
+4. [x] Verify embedded build passes
+
+### Out of Scope
+
+- **Position holding**: Hold mode is passive stop only; Loiter mode handles position correction
+- **Parameter configuration**: ArduPilot Hold mode has no parameters
+- **Mode switching logic**: How/when to switch to Hold mode is handled by failsafe and command handler systems
+- **Brake functionality**: ArduPilot has a separate "Brake" concept; Hold simply zeros outputs
+
+## Appendix
+
+### References
+
+**ArduPilot Documentation:**
+
+- [Hold Mode (Rover)](https://ardupilot.org/rover/docs/hold-mode.html)
+
+**Related Project Documents:**
+
+- [AN-00014-mode-lifecycle-management](AN-00014-mode-lifecycle-management.md): Mode lifecycle patterns
+- [AN-00011-failsafe-system](AN-00011-failsafe-system.md): Failsafe system using Hold as fallback
+- [FB-016 Feature Backlog](../feature-backlog.md): Original Hold mode feature request
+
+### Raw Data
+
+**HoldMode Implementation Sketch:**
+
+```rust
+pub struct HoldMode {
+    actuators: Box<dyn ActuatorInterface>,
+}
+
+impl HoldMode {
+    pub fn new(actuators: Box<dyn ActuatorInterface>) -> Self {
+        Self { actuators }
+    }
+}
+
+impl Mode for HoldMode {
+    fn enter(&mut self) -> Result<(), &'static str> {
+        self.actuators.set_steering(0.0)?;
+        self.actuators.set_throttle(0.0)?;
+        Ok(())
+    }
+
+    fn update(&mut self, _dt: f32) -> Result<(), &'static str> {
+        self.actuators.set_steering(0.0)?;
+        self.actuators.set_throttle(0.0)?;
+        Ok(())
+    }
+
+    fn exit(&mut self) -> Result<(), &'static str> {
+        self.actuators.set_steering(0.0)?;
+        self.actuators.set_throttle(0.0)?;
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "Hold"
+    }
+}
+```
+
+**Existing MotorControlRunner Hold handling (defense-in-depth):**
+
+```rust
+// crates/core/src/motor/runner.rs, line 73
+FlightMode::Hold => {
+    return MotorControlOutput {
+        motor_speeds: [0.0; 4],
+        should_stop: true,
+    };
+}
+```

--- a/docs/feature-backlog.md
+++ b/docs/feature-backlog.md
@@ -11,233 +11,13 @@ This document tracks planned features outside the formal TDL process. Features h
 
 ---
 
-## Control Modes
-
-### FB-001: Circle Mode
-
-**Status**: In Progress
-
-**Description**: Navigate in a circular path around a specified center point at a configurable radius and speed.
-
-**Use Cases**:
-
-- Survey/inspection of a specific area
-- Aerial photography patterns (adapted for ground)
-- Perimeter patrol around a fixed point
-
-**ArduPilot Reference**: [Circle Mode](https://ardupilot.org/rover/docs/circle-mode.html)
-
-**Key Parameters** (ArduPilot standard):
-
-| Parameter        | Description                         | Default |
-| ---------------- | ----------------------------------- | ------- |
-| `CIRCLE_RADIUS`  | Circle radius in meters             | 20      |
-| `CIRCLE_RATE`    | Angular rate in deg/sec (+ = CW)    | 20      |
-| `CIRCLE_OPTIONS` | Bitmask for circle behavior options | 0       |
-
-**Behavior**:
-
-1. When entering Circle mode, current position becomes initial center (or use commanded center)
-2. Vehicle moves to circle perimeter at closest point
-3. Follows circular path at specified radius and rate
-4. Maintains constant ground speed based on radius and angular rate
-5. Exit via mode change or RC input
-
-**Implementation Considerations**:
-
-- Requires heading control (steering) and speed control (throttle)
-- Center point can be current position or GCS-commanded
-- Direction (CW/CCW) controlled by sign of `CIRCLE_RATE`
-- Speed = radius × angular_rate (rad/s)
-
-**Dependencies**:
-
-- GPS position
-- Heading control (AHRS)
-- Waypoint navigation infrastructure
-
----
-
-### FB-002: Loiter Mode
-
-**Status**: Proposed
-
-**Description**: Hold current position. For rovers, this means stopping and actively correcting position drift.
-
-**Use Cases**:
-
-- Temporary stop during operation
-- Position hold while waiting for commands
-- Station keeping for boats
-
-**ArduPilot Reference**: [Loiter Mode (Rover)](https://ardupilot.org/rover/docs/loiter-mode.html)
-
-**Key Parameters** (ArduPilot standard):
-
-| Parameter     | Description                      | Default |
-| ------------- | -------------------------------- | ------- |
-| `LOIT_RADIUS` | Loiter radius (0 = point loiter) | 2       |
-| `LOIT_TYPE`   | 0=stop, 1=hold position          | 0       |
-
-**Behavior**:
-
-- **Type 0 (Stop)**: Simply stop motors, no active position holding
-- **Type 1 (Hold)**: Actively correct position if drifted beyond threshold
-
-**For Rovers**:
-
-1. Record current position as loiter point
-2. Stop motors
-3. If position drifts > threshold, navigate back to loiter point
-4. Repeat until mode change
-
-**For Boats**:
-
-1. More active station keeping due to current/wind
-2. Continuous small corrections to maintain position
-3. May involve forward/reverse and steering adjustments
-
-**Implementation Considerations**:
-
-- Simple stop mode is trivial (just zero outputs)
-- Active hold requires position error calculation and correction
-- Boat variant needs more aggressive correction due to drift
-- Threshold for "close enough" prevents oscillation
-
-**Dependencies**:
-
-- GPS position
-- Position error calculation
-- Basic navigation to point
-
----
-
-### FB-003: Smart RTL (Return to Launch)
-
-**Status**: Proposed
-
-**Description**: Return to launch point by retracing the path taken, rather than direct line. Useful for avoiding obstacles encountered on the way out.
-
-**Use Cases**:
-
-- Return through complex terrain
-- Avoid retracing through obstacles
-- Safe return when direct path is unknown
-
-**ArduPilot Reference**: [SmartRTL](https://ardupilot.org/rover/docs/smartrtl-mode.html)
-
-**Key Parameters** (ArduPilot standard):
-
-| Parameter       | Description                           | Default |
-| --------------- | ------------------------------------- | ------- |
-| `SRTL_ACCURACY` | Path simplification accuracy (meters) | 2       |
-| `SRTL_POINTS`   | Max breadcrumb points to store        | 300     |
-
-**Behavior**:
-
-1. During operation, periodically record "breadcrumb" positions
-2. Apply path simplification (Douglas-Peucker algorithm) to reduce points
-3. When SmartRTL activated:
-   - Navigate to nearest breadcrumb
-   - Follow breadcrumbs in reverse order
-   - End at launch point
-4. If breadcrumb buffer full, oldest points pruned (with path simplification)
-
-**Path Simplification**:
-
-- Douglas-Peucker algorithm reduces points while preserving path shape
-- `SRTL_ACCURACY` controls how much simplification is allowed
-- Balance between memory usage and path fidelity
-
-**Memory Considerations** (RP2350: 520KB RAM):
-
-- Each point: \~12 bytes (lat/lon as i32 + alt as i16)
-- 300 points: \~3.6KB
-- Acceptable for RP2350, may need reduction for RP2040
-
-**Implementation Considerations**:
-
-- Breadcrumb recording interval: distance-based (e.g., every 3m) not time-based
-- Path simplification runs periodically or when buffer near full
-- Waypoint navigation infrastructure reused for following breadcrumbs
-- Fallback to direct RTL if breadcrumbs unavailable
-
-**Dependencies**:
-
-- GPS position
-- Waypoint navigation
-- Path simplification algorithm
-- Persistent breadcrumb storage (RAM, not Flash)
-
----
-
 ## Safety Features
-
-### FB-004: Battery RTL
-
-**Status**: In Progress
-
-**Analysis**: [AN-00035-battery-rtl](analysis/AN-00035-battery-rtl.md)
-
-**Description**: Automatic Return to Launch when battery reaches critical level, with distance-aware thresholds.
-
-**Use Cases**:
-
-- Prevent vehicle stranding due to empty battery
-- Automatic safety return without operator intervention
-- Distance-aware decision making
-
-**ArduPilot Reference**: [Failsafe](https://ardupilot.org/rover/docs/rover-failsafes.html)
-
-**Key Parameters** (ArduPilot standard):
-
-| Parameter         | Description                                            | Default |
-| ----------------- | ------------------------------------------------------ | ------- |
-| `BATT_LOW_VOLT`   | Low battery voltage threshold                          | 10.5    |
-| `BATT_CRT_VOLT`   | Critical battery voltage threshold                     | 10.0    |
-| `BATT_FS_LOW_ACT` | Low battery action (0=none, 1=RTL, 2=hold, 3=SmartRTL) | 0       |
-| `BATT_FS_CRT_ACT` | Critical battery action                                | 0       |
-| `BATT_CAPACITY`   | Battery capacity in mAh                                | 0       |
-| `BATT_LOW_MAH`    | Low battery remaining mAh                              | 0       |
-| `BATT_CRT_MAH`    | Critical battery remaining mAh                         | 0       |
-
-**Behavior Levels**:
-
-1. **Low Battery** (`BATT_LOW_VOLT` or `BATT_LOW_MAH`):
-   - Warning notification (buzzer, telemetry)
-   - Optional action: RTL, Hold, SmartRTL, or continue
-
-2. **Critical Battery** (`BATT_CRT_VOLT` or `BATT_CRT_MAH`):
-   - Urgent notification
-   - Forced action: typically RTL or SmartRTL
-
-**Distance-Aware Enhancement** (beyond ArduPilot standard):
-
-- Calculate estimated battery needed to return home
-- Factor in: distance to home, average consumption rate, safety margin
-- Trigger RTL when: remaining_capacity < return_estimate × safety_factor
-
-**Implementation Considerations**:
-
-- Requires battery voltage/current monitoring (ADC)
-- mAh tracking requires current sensor integration
-- Consumption estimation from historical data
-- Hysteresis to prevent oscillation near threshold
-
-**Dependencies**:
-
-- Battery voltage ADC
-- Optional: Current sensor
-- RTL or SmartRTL mode
-- Distance to home calculation
-
----
 
 ### FB-005: Communication Lost Action
 
 **Status**: Proposed
 
-**Description**: Configurable behavior when GCS communication is lost (no heartbeat received).
+**Description**: Configurable behavior when GCS communication is lost (no heartbeat received). Parameters (`FS_GCS_ENABLE`, `FS_ACTION`, `FS_TIMEOUT`) and `FailsafeAction` enum exist in core, but the active GCS heartbeat monitoring loop and mode transition trigger are not wired.
 
 **Use Cases**:
 
@@ -275,8 +55,201 @@ This document tracks planned features outside the formal TDL process. Features h
 **Dependencies**:
 
 - Heartbeat tracking (already in MAVLink handler)
-- RTL/SmartRTL/Hold modes
-- Mode switching infrastructure
+- RTL/SmartRTL/Hold modes (implemented)
+- Mode switching infrastructure (implemented)
+
+---
+
+### FB-017: Geofence
+
+**Status**: Proposed
+
+**Description**: Define geographic boundaries that the vehicle must stay within (inclusion fence) or avoid (exclusion fence). Trigger configurable action on breach.
+
+**Use Cases**:
+
+- Prevent rover from leaving designated area
+- Keep boat within safe water boundaries
+- Regulatory compliance for autonomous operation
+
+**ArduPilot Reference**: [Rover Fence](https://ardupilot.org/rover/docs/rover-fence.html)
+
+**Key Parameters** (ArduPilot standard):
+
+| Parameter      | Description                                         | Default |
+| -------------- | --------------------------------------------------- | ------- |
+| `FENCE_ENABLE` | Enable/disable fence                                | 0       |
+| `FENCE_TYPE`   | Bitmask: 1=max altitude, 2=circle, 4=polygon        | 6       |
+| `FENCE_ACTION` | Breach action (0=report, 1=RTL, 2=hold, 3=SmartRTL) | 1       |
+| `FENCE_RADIUS` | Circular fence radius (m)                           | 100     |
+| `FENCE_MARGIN` | Distance from fence to trigger warning (m)          | 2       |
+
+**Behavior**:
+
+1. **Circular fence**: Simple radius from home position
+2. **Polygon fence**: Uploaded via mission protocol as FENCE_POINT items
+3. On breach: execute configured action (RTL, Hold, SmartRTL, or report-only)
+4. Warning zone inside fence boundary for early notification
+
+**Implementation Considerations**:
+
+- Circular fence is simplest (distance from home < radius)
+- Polygon fence requires point-in-polygon algorithm (ray casting)
+- Check position against fence at navigation update rate
+- Memory: polygon points stored similarly to waypoints
+- RP2350 can handle \~50 polygon points easily
+
+**Dependencies**:
+
+- GPS position
+- Home position (FB-014)
+- RTL / Hold modes
+
+---
+
+### FB-018: LED Status Patterns
+
+**Status**: Proposed
+
+**Description**: Define LED blink patterns to indicate vehicle state without GCS connection.
+
+**Use Cases**:
+
+- Field debugging without laptop
+- Visual confirmation of GPS fix, armed state, errors
+- Safety indicator visible from distance
+
+**Patterns**:
+
+| State                | Pattern           |
+| -------------------- | ----------------- |
+| Disarmed, no GPS     | Slow blink (1 Hz) |
+| Disarmed, GPS fix    | Double blink      |
+| Armed                | Solid on          |
+| Failsafe active      | Fast blink (4 Hz) |
+| Error / pre-arm fail | Triple blink      |
+| Calibrating          | Breathing / fade  |
+
+**Implementation Considerations**:
+
+- PIN_LED already defined in board configuration
+- State machine driven by vehicle state (armed, GPS fix, failsafe, etc.)
+- Run as low-priority scheduler task (\~10 Hz)
+- PWM for brightness control / breathing effect (optional)
+
+**Dependencies**:
+
+- GPIO output (existing)
+- Vehicle state (existing SYSTEM_STATE)
+
+---
+
+### FB-019: Buzzer Alert Patterns
+
+**Status**: Proposed
+
+**Description**: Define buzzer tone patterns for audible state indication and alerts.
+
+**Use Cases**:
+
+- Arming/disarming confirmation
+- Low battery audible warning
+- GPS fix acquired notification
+- Pre-arm check failure alert
+
+**Patterns**:
+
+| Event               | Pattern                  |
+| ------------------- | ------------------------ |
+| Arm success         | Rising tone              |
+| Disarm              | Falling tone             |
+| GPS fix acquired    | Two short beeps          |
+| Low battery warning | Periodic beep (every 5s) |
+| Critical battery    | Continuous rapid beep    |
+| Pre-arm failure     | Three descending tones   |
+| Failsafe triggered  | Siren pattern            |
+
+**Implementation Considerations**:
+
+- PIN_BUZZER already defined in board configuration
+- PWM frequency control for different tones
+- Non-blocking: queue patterns, play asynchronously
+- Respect user preference (enable/disable via parameter)
+
+**Dependencies**:
+
+- PWM output (existing)
+- Vehicle state events
+
+---
+
+### FB-020: Watchdog Timer
+
+**Status**: Proposed
+
+**Description**: Hardware watchdog to detect and recover from software hangs on the embedded target.
+
+**Use Cases**:
+
+- Recover from infinite loops or deadlocks
+- Safety reset if main loop stalls
+- Critical for unattended autonomous operation
+
+**Behavior**:
+
+1. Initialize hardware watchdog with timeout (e.g., 2 seconds)
+2. Main loop feeds (kicks) the watchdog each iteration
+3. If main loop stalls, watchdog triggers hardware reset
+4. After reset, detect watchdog-caused boot and log it
+5. Optionally: enter safe mode after watchdog reset
+
+**Implementation Considerations**:
+
+- RP2350 has built-in watchdog peripheral
+- `embassy-rp` provides watchdog API
+- Timeout must be longer than worst-case main loop iteration
+- Log watchdog resets to flash for post-mortem analysis
+- Consider: should watchdog reset enter a safe mode or resume normal operation?
+
+**Dependencies**:
+
+- RP2350 watchdog peripheral
+- Boot detection (watchdog vs. normal boot)
+
+---
+
+## Control Modes
+
+### FB-016: Hold Mode
+
+**Status**: Done
+
+**Description**: Explicit "stop and hold" mode. Vehicle stops all motor output and remains stationary. `FlightMode::Hold` variant exists in the enum but no `Mode` trait implementation struct exists yet.
+
+**Use Cases**:
+
+- Operator-initiated stop without switching to Manual
+- Default safe state for unknown situations
+- Failsafe fallback when GPS is unavailable (can't do RTL or Loiter)
+
+**ArduPilot Reference**: [Hold Mode](https://ardupilot.org/rover/docs/hold-mode.html)
+
+**Behavior**:
+
+1. Zero throttle and steering outputs
+2. No GPS required (works without position fix)
+3. No active position correction (contrast with Loiter Type 1)
+4. Remain in Hold until operator changes mode
+
+**Implementation Considerations**:
+
+- Simplest possible mode: just zero all outputs
+- Good candidate for failsafe fallback when GPS unavailable
+- ArduPilot custom mode number: 4
+
+**Dependencies**:
+
+- Mode framework (existing)
 
 ---
 
@@ -336,56 +309,107 @@ This document tracks planned features outside the formal TDL process. Features h
 
 ---
 
-### FB-007: Speed Profile
+## MAVLink Protocol Completeness
+
+### FB-013: Log Download Protocol
 
 **Status**: Proposed
 
-**Description**: Configure different maximum speeds for different mission segments or areas.
+**Description**: MAVLink log download protocol for retrieving flight logs from vehicle to GCS for post-analysis.
 
 **Use Cases**:
 
-- Slow down in confined areas
-- Speed up on open terrain
-- Precision vs. speed trade-off per waypoint
+- Download flight logs in Mission Planner
+- Post-mission analysis and debugging
+- Long-term data collection
 
-**ArduPilot Reference**: `DO_CHANGE_SPEED` command
+**MAVLink Messages**:
 
-**MAVLink Implementation**:
-
-Mission command `MAV_CMD_DO_CHANGE_SPEED` (178):
-
-| Parameter | Description                   |
-| --------- | ----------------------------- |
-| param1    | Speed type (0=ground speed)   |
-| param2    | Speed in m/s (-1 = no change) |
-| param3    | Throttle % (-1 = no change)   |
-
-**Behavior**:
-
-1. Default speed from `WP_SPEED` parameter
-2. `DO_CHANGE_SPEED` command in mission changes speed
-3. New speed applies to subsequent waypoints
-4. Persists until next `DO_CHANGE_SPEED` or mission end
-
-**Key Parameters** (ArduPilot standard):
-
-| Parameter      | Description                  | Default |
-| -------------- | ---------------------------- | ------- |
-| `WP_SPEED`     | Default waypoint speed (m/s) | 2       |
-| `WP_SPEED_MIN` | Minimum speed (m/s)          | 0       |
+| Message            | Direction     | Description                          |
+| ------------------ | ------------- | ------------------------------------ |
+| `LOG_REQUEST_LIST` | GCS → Vehicle | Request available log list           |
+| `LOG_ENTRY`        | Vehicle → GCS | Describe a log file (id, size, time) |
+| `LOG_REQUEST_DATA` | GCS → Vehicle | Request log data bytes               |
+| `LOG_DATA`         | Vehicle → GCS | Send log data chunk (90 bytes)       |
+| `LOG_ERASE`        | GCS → Vehicle | Erase all logs                       |
 
 **Implementation Considerations**:
 
-- Speed stored in mission item, not separate data structure
-- Apply speed limit in throttle/speed controller
-- Smooth speed transitions (acceleration limiting)
-- Interaction with terrain/slope (future)
+- Flash-based log storage with index (existing ring buffer in core)
+- Log segmentation: new log per arm/disarm cycle
+- Chunk-based transfer with offset/count
+- Memory-efficient streaming (don't load entire log to RAM)
 
 **Dependencies**:
 
-- Mission item parsing
-- Speed controller
-- Acceleration limiting (existing S-curve planner)
+- Logging infrastructure (FR-00002, FR-00095–FR-00097)
+- Flash storage
+
+---
+
+### FB-014: Home Position Management
+
+**Status**: Proposed
+
+**Description**: Track, report, and allow setting of home position for RTL and distance calculations.
+
+**Use Cases**:
+
+- RTL destination
+- Distance-to-home display in GCS
+- Allow GCS to override home position
+
+**MAVLink Messages**:
+
+| Message               | Direction     | Description                                           |
+| --------------------- | ------------- | ----------------------------------------------------- |
+| `HOME_POSITION`       | Vehicle → GCS | Report current home position (periodic)               |
+| `SET_HOME_POSITION`   | GCS → Vehicle | Override home position                                |
+| `MAV_CMD_DO_SET_HOME` | GCS → Vehicle | Set home to current position or specified coordinates |
+
+**Behavior**:
+
+1. Home position set automatically on first GPS fix after arming
+2. GCS can override via SET_HOME_POSITION or DO_SET_HOME
+3. Reported in HOME_POSITION message at \~1 Hz
+4. Used by RTL, SmartRTL, battery RTL, and distance-to-home calculations
+
+**Dependencies**:
+
+- GPS position
+- RTL mode (implemented)
+
+---
+
+### FB-015: Time Synchronization
+
+**Status**: Proposed
+
+**Description**: GPS-based time synchronization and SYSTEM_TIME MAVLink message for correlating vehicle logs with GCS timestamps.
+
+**Use Cases**:
+
+- Correlate flight logs with GCS event log
+- Accurate timestamps in telemetry messages
+- Sync multi-vehicle logs in post-analysis
+
+**MAVLink Messages**:
+
+| Message       | Direction     | Description                     |
+| ------------- | ------------- | ------------------------------- |
+| `SYSTEM_TIME` | Vehicle → GCS | Report Unix time and boot time  |
+| `TIMESYNC`    | Both          | Round-trip time synchronization |
+
+**Implementation Considerations**:
+
+- GPS provides UTC time after fix
+- Boot time from embassy monotonic clock
+- Emit SYSTEM_TIME at \~1 Hz
+
+**Dependencies**:
+
+- GPS time (from NMEA/UBX time fields)
+- Embassy time (existing)
 
 ---
 
@@ -550,46 +574,260 @@ eta = distance_remaining / current_speed
 
 ---
 
+## SITL Enhancements
+
+### FB-021: SITL Sensor Fault Injection
+
+**Status**: Proposed
+
+**Description**: Simulate sensor failures and degraded conditions in SITL to test failsafe behavior.
+
+**Use Cases**:
+
+- Test GPS loss failsafe triggers RTL/Hold correctly
+- Test battery low voltage triggers Battery RTL
+- Verify RC loss handling
+- Regression testing for safety-critical code paths
+
+**Fault Types**:
+
+| Fault                | Description                                     |
+| -------------------- | ----------------------------------------------- |
+| GPS loss             | Stop providing GPS data after N steps           |
+| GPS drift            | Add large position offset to simulate multipath |
+| Battery drain        | Simulate voltage drop over time                 |
+| Battery critical     | Instant drop to critical voltage                |
+| RC loss              | Stop RC input messages                          |
+| IMU failure          | Send invalid/frozen IMU data                    |
+| Compass interference | Add large magnetic offset                       |
+
+**Implementation Considerations**:
+
+- Inject at adapter level (LightweightAdapter or GazeboAdapter)
+- Time-triggered or command-triggered (via test API or special MAVLink command)
+- Deterministic with lockstep mode for repeatable CI tests
+- Record fault injection events in test logs
+
+**Dependencies**:
+
+- SITL bridge (existing)
+- Failsafe system (existing parameters)
+- Lockstep time mode (existing)
+
+---
+
+### FB-022: SITL Scenario Test Framework
+
+**Status**: Proposed
+
+**Description**: Automated scenario tests using LightweightAdapter + lockstep for deterministic CI verification of autopilot behavior.
+
+**Use Cases**:
+
+- Regression testing: arm → auto mode → complete mission → disarm
+- Failsafe verification: GPS loss during mission triggers RTL
+- Mode transition testing: Manual → Guided → Auto → RTL
+- Navigation accuracy: verify waypoint arrival within tolerance
+
+**Scenario Examples**:
+
+| Scenario         | Description                                       |
+| ---------------- | ------------------------------------------------- |
+| Basic mission    | Upload 3 waypoints, run Auto, verify all reached  |
+| RTL on GPS loss  | Fly to waypoint 2, inject GPS loss, verify RTL    |
+| Mode transitions | Cycle through all modes, verify state consistency |
+| Arm/disarm cycle | Arm, run, disarm, verify clean shutdown           |
+| Battery failsafe | Inject low voltage, verify Battery RTL triggers   |
+| Geofence breach  | Navigate outside fence, verify RTL triggers       |
+
+**Implementation Considerations**:
+
+- Build on existing `cargo test -p pico_trail_sitl` infrastructure
+- Each scenario: setup bridge → inject commands → step N times → assert state
+- Deterministic via lockstep + seeded RNG
+- Timeout protection for stuck tests
+- Report: pass/fail + final vehicle state + step count
+
+**Dependencies**:
+
+- LightweightAdapter (existing)
+- Lockstep time mode (existing)
+- Fault injection (FB-021)
+
+---
+
+## Hardware Features
+
+### FB-023: Servo/PWM Output Calibration
+
+**Status**: Proposed
+
+**Description**: Calibrate PWM output ranges (min/max/trim) to match physical actuators.
+
+**Use Cases**:
+
+- Different motors/ESCs have different PWM ranges
+- Trim adjustment for mechanical asymmetry
+- Reverse direction for incorrectly wired motors
+
+**Key Parameters** (ArduPilot standard):
+
+| Parameter         | Description                | Default |
+| ----------------- | -------------------------- | ------- |
+| `SERVO1_MIN`      | Minimum PWM (us)           | 1000    |
+| `SERVO1_MAX`      | Maximum PWM (us)           | 2000    |
+| `SERVO1_TRIM`     | Neutral PWM (us)           | 1500    |
+| `SERVO1_REVERSED` | Reverse output             | 0       |
+| `SERVO1_FUNCTION` | Output function assignment | 0       |
+
+**Implementation Considerations**:
+
+- Map normalized output (-1.0 to 1.0) to calibrated PWM range
+- Per-channel configuration (up to 4 channels for differential drive)
+- Calibration wizard via GCS (optional, manual parameter entry sufficient)
+
+**Dependencies**:
+
+- PWM output (existing)
+- Parameter system (existing)
+
+---
+
+### FB-024: OTA Firmware Update
+
+**Status**: Proposed
+
+**Description**: Update firmware over WiFi or USB without physical BOOTSEL button press.
+
+**Use Cases**:
+
+- Field firmware update without disassembly
+- Remote fleet management
+- Faster development cycle
+
+**Approaches**:
+
+| Approach                | Pros             | Cons                                 |
+| ----------------------- | ---------------- | ------------------------------------ |
+| USB UF2 (current)       | Simple, reliable | Requires physical access             |
+| WiFi HTTP upload        | Remote capable   | Needs bootloader, flash partitioning |
+| MAVLink firmware upload | GCS integrated   | Complex, slow over MAVLink           |
+
+**Implementation Considerations**:
+
+- RP2350 has 4MB flash; dual-bank A/B partitioning possible
+- Write new firmware to inactive bank, swap on reboot
+- Verify firmware CRC before swap
+- Fallback: if new firmware fails boot, revert to previous
+- WiFi HTTP server for upload (simplest remote approach)
+
+**Dependencies**:
+
+- Flash partitioning
+- CRC verification
+- WiFi stack (existing cyw43)
+
+---
+
+## Boat-Specific Features
+
+### FB-025: Boat Station Keeping
+
+**Status**: Proposed
+
+**Description**: Active position holding for boats, compensating for wind and current drift. More aggressive than rover Loiter due to continuous environmental forces.
+
+**Use Cases**:
+
+- Hold position during data collection
+- Anchor-free station keeping
+- Waiting at rendezvous point
+
+**Behavior**:
+
+1. Record target position
+2. Continuously calculate position error
+3. Apply proportional corrections (throttle + steering)
+4. Handle heading into current/wind for efficiency
+5. Configurable correction aggressiveness
+
+**Implementation Considerations**:
+
+- Extension of Loiter Type 1 with more aggressive tuning
+- May need separate PID gains from rover navigation
+- Optional: estimate current direction from drift pattern
+- Power consumption: continuous motor operation
+
+**Dependencies**:
+
+- GPS position
+- Navigation controller (existing)
+- Loiter mode framework (implemented)
+
+---
+
 ## Priority Matrix
 
-| Feature                   | Complexity | Value  | Dependencies      | Priority |
-| ------------------------- | ---------- | ------ | ----------------- | -------- |
-| FB-002 Loiter             | Low        | High   | GPS, basic nav    | High     |
-| FB-005 Comm Lost          | Low        | High   | Existing modes    | High     |
-| FB-006 Pause/Resume       | Medium     | High   | Auto mode         | High     |
-| FB-001 Circle             | Medium     | Medium | Heading control   | Medium   |
-| FB-003 SmartRTL           | High       | High   | Path storage, nav | Medium   |
-| FB-004 Battery RTL        | Medium     | High   | Battery monitor   | Medium   |
-| FB-007 Speed Profile      | Low        | Medium | Mission parser    | Medium   |
-| FB-008 Trip Stats         | Low        | Medium | GPS, timer        | Low      |
-| FB-010 Mission Progress   | Low        | Medium | Mission storage   | Low      |
-| FB-009 Battery Prediction | Medium     | Medium | Current sensor    | Low      |
+| Feature                   | Complexity | Value  | Dependencies    | Priority     |
+| ------------------------- | ---------- | ------ | --------------- | ------------ |
+| FB-016 Hold Mode          | Very Low   | High   | Mode framework  | **Critical** |
+| FB-014 Home Position      | Low        | High   | GPS             | **Critical** |
+| FB-005 Comm Lost          | Low        | High   | Existing modes  | **High**     |
+| FB-017 Geofence           | Medium     | High   | GPS, Home       | High         |
+| FB-006 Pause/Resume       | Medium     | High   | Auto mode       | High         |
+| FB-018 LED Patterns       | Very Low   | Medium | GPIO            | High         |
+| FB-019 Buzzer Patterns    | Low        | Medium | PWM             | High         |
+| FB-020 Watchdog           | Low        | High   | RP2350 HW       | Medium       |
+| FB-021 Fault Injection    | Medium     | High   | SITL bridge     | Medium       |
+| FB-022 Scenario Tests     | Medium     | High   | SITL, missions  | Medium       |
+| FB-023 Servo Calibration  | Low        | Medium | PWM, params     | Medium       |
+| FB-015 Time Sync          | Low        | Low    | GPS time        | Low          |
+| FB-008 Trip Stats         | Low        | Medium | GPS, timer      | Low          |
+| FB-010 Mission Progress   | Low        | Medium | Mission storage | Low          |
+| FB-009 Battery Prediction | Medium     | Medium | Current sensor  | Low          |
+| FB-013 Log Download       | Medium     | Medium | Flash storage   | Low          |
+| FB-024 OTA Update         | High       | Medium | Flash, WiFi     | Low          |
+| FB-025 Boat Station Keep  | Medium     | Medium | Loiter, nav     | Low          |
 
 ---
 
 ## Implementation Order Suggestion
 
-**Phase 1: Foundation Modes**
+**Phase 1: Critical Foundation**
 
-1. Loiter (FB-002) - Simple, high value
-2. Communication Lost Action (FB-005) - Safety critical
+1. Hold Mode (FB-016) - Simplest mode, failsafe fallback
+2. Home Position (FB-014) - RTL/geofence prerequisite
+3. Communication Lost Action (FB-005) - Safety critical, params already exist
 
-**Phase 2: Mission Enhancement**
+**Phase 2: Safety & Operator UX**
 
-3. Mission Pause/Resume (FB-006) - Common need
-4. Speed Profile (FB-007) - Low effort, useful
+4. Geofence (FB-017) - Area restriction
+5. LED Patterns (FB-018) - Field status visibility
+6. Buzzer Patterns (FB-019) - Audible alerts
+7. Watchdog (FB-020) - Hang recovery
 
-**Phase 3: Advanced Modes**
+**Phase 3: Mission Enhancement**
 
-5. Circle (FB-001) - Survey capability
-6. SmartRTL (FB-003) - Complex but valuable
+8. Mission Pause/Resume (FB-006) - Common operational need
 
-**Phase 4: Safety & Monitoring**
+**Phase 4: SITL Testing Infrastructure**
 
-7. Battery RTL (FB-004) - Requires battery monitoring
-8. Trip Statistics (FB-008) - Foundation for predictions
-9. Mission Progress (FB-010) - User awareness
-10. Battery Prediction (FB-009) - Requires current sensor
+9. Sensor Fault Injection (FB-021) - Failsafe test enabler
+10. Scenario Test Framework (FB-022) - CI regression tests
+
+**Phase 5: Telemetry & Hardware**
+
+11. Servo Calibration (FB-023) - Hardware tuning
+12. Trip Statistics (FB-008) - Foundation for predictions
+13. Mission Progress (FB-010) - User awareness
+14. Time Sync (FB-015) - Log correlation
+
+**Phase 6: Advanced**
+
+15. Battery Prediction (FB-009) - Requires current sensor
+16. Log Download (FB-013) - Post-flight analysis
+17. Boat Station Keeping (FB-025) - Boat-specific
+18. OTA Update (FB-024) - Remote updates
 
 ---
 

--- a/docs/requirements/FR-00062-control-modes.md
+++ b/docs/requirements/FR-00062-control-modes.md
@@ -22,6 +22,7 @@
   - [FR-00043-manual-mode-implementation](FR-00043-manual-mode-implementation.md)
   - [FR-00003-failsafe-mechanisms](FR-00003-failsafe-mechanisms.md)
   - [FR-00041-gcs-loss-failsafe](FR-00041-gcs-loss-failsafe.md)
+  - [FR-00168-hold-mode-actuator-stop](FR-00168-hold-mode-actuator-stop.md)
 
 - Related Tasks: N/A - Tasks will be created after ADRs
 

--- a/docs/requirements/FR-00168-hold-mode-actuator-stop.md
+++ b/docs/requirements/FR-00168-hold-mode-actuator-stop.md
@@ -1,0 +1,91 @@
+# FR-00168 Hold Mode Actuator Stop
+
+## Metadata
+
+- Type: Functional Requirement
+- Status: Implemented
+
+## Links
+
+- Prerequisite Requirements:
+  - [FR-00062-control-modes](FR-00062-control-modes.md)
+- Dependent Requirements:
+  - [FR-00169-hold-mode-identity](FR-00169-hold-mode-identity.md)
+  - [NFR-00170-hold-mode-performance](NFR-00170-hold-mode-performance.md)
+- Related Tasks:
+  - [T-00171-hold-mode](../tasks/T-00171-hold-mode/README.md)
+
+## Requirement Statement
+
+The system shall provide a Hold mode that implements the `Mode` trait, always succeeds on entry, and sets all actuator outputs (steering and throttle) to zero on entry, every update cycle, and exit.
+
+## Rationale
+
+Hold mode is the simplest and most reliable control mode. It must:
+
+- Serve as the default failsafe fallback when other modes cannot be entered (e.g., no GPS for RTL/Loiter)
+- Provide a safe, predictable stopped state for battery failsafe (`BatteryFailsafeAction::Hold`)
+- Allow GCS to command a full stop via standard ArduPilot SET_MODE (custom mode 4)
+- Work without any external dependencies (no GPS, no RC input, no navigation)
+
+The `FlightMode::Hold` enum variant and MAVLink mapping already exist, but no `Mode` trait implementation struct exists to use with `ModeExecutor`.
+
+## User Story
+
+As a failsafe system, I want Hold mode to always succeed entry and produce zero motor output, so that the vehicle reliably stops in any failure scenario.
+
+## Acceptance Criteria
+
+- [x] `HoldMode` struct exists and implements `Mode` trait
+- [x] `HoldMode::new()` constructor accepts `Box<dyn ActuatorInterface>`
+- [x] `enter()` always returns `Ok(())` with no preconditions
+- [x] `enter()` sets steering to 0.0 and throttle to 0.0
+- [x] `update()` sets steering to 0.0 and throttle to 0.0
+- [x] `exit()` sets steering to 0.0 and throttle to 0.0
+- [x] `HoldMode` can be passed to `ModeExecutor::set_mode()`
+
+## Technical Details
+
+### Functional Requirement Details
+
+**Mode Entry:**
+
+1. Set steering to 0.0 via `ActuatorInterface::set_steering()`
+2. Set throttle to 0.0 via `ActuatorInterface::set_throttle()`
+3. Return `Ok(())` unconditionally (no GPS, RC, or other checks)
+
+**Mode Update (50 Hz):**
+
+1. Set steering to 0.0
+2. Set throttle to 0.0
+3. Ignore `dt` parameter (no time-dependent behavior)
+
+**Mode Exit:**
+
+1. Set steering to 0.0
+2. Set throttle to 0.0
+
+**Defense-in-Depth:**
+
+`MotorControlRunner::step()` already returns zero output for `FlightMode::Hold`. The `HoldMode` trait implementation provides a second layer of safety, ensuring actuators are zeroed regardless of motor control path.
+
+## Platform Considerations
+
+N/A - Platform agnostic (uses `ActuatorInterface` abstraction)
+
+## Risks & Mitigation
+
+| Risk                          | Impact | Likelihood | Mitigation                                    | Validation                   |
+| ----------------------------- | ------ | ---------- | --------------------------------------------- | ---------------------------- |
+| ActuatorInterface write fails | Low    | Very Low   | Log error, continue (vehicle already stopped) | Unit test with mock actuator |
+
+## Implementation Notes
+
+- Create `crates/core/src/mode/hold.rs` following the pattern of `manual.rs`
+- Add `pub mod hold;` and re-export in `crates/core/src/mode/mod.rs`
+- No parameters needed (ArduPilot Hold mode has no dedicated parameters)
+- No `can_enter()` needed (no preconditions)
+
+## External References
+
+- [ArduPilot Hold Mode (Rover)](https://ardupilot.org/rover/docs/hold-mode.html) - Official documentation

--- a/docs/requirements/FR-00169-hold-mode-identity.md
+++ b/docs/requirements/FR-00169-hold-mode-identity.md
@@ -1,0 +1,65 @@
+# FR-00169 Hold Mode Identity Reporting
+
+## Metadata
+
+- Type: Functional Requirement
+- Status: Implemented
+
+## Links
+
+- Prerequisite Requirements:
+  - [FR-00168-hold-mode-actuator-stop](FR-00168-hold-mode-actuator-stop.md)
+- Dependent Requirements: N/A – no downstream requirements depend on this
+- Related Tasks:
+  - [T-00171-hold-mode](../tasks/T-00171-hold-mode/README.md)
+
+## Requirement Statement
+
+The Hold mode shall report its identity as "Hold" via the `Mode::name()` method for consistent telemetry and logging.
+
+## Rationale
+
+Mode transition logging uses `Mode::name()` to identify the active mode. The name must match the ArduPilot convention ("Hold") and the `FlightMode::Hold` display name ("HOLD") for GCS operator clarity. Consistent naming ensures:
+
+- Mode transition log messages are unambiguous
+- Debugging can correlate ModeExecutor state with FlightMode enum
+- GCS displays match expected ArduPilot behavior
+
+## User Story
+
+As a field operator reviewing logs, I want Hold mode transitions to be clearly identified by name, so that I can distinguish them from Manual, Loiter, and other modes.
+
+## Acceptance Criteria
+
+- [x] `HoldMode::name()` returns `"Hold"`
+- [x] Mode transition log message includes "Hold" when entering or exiting
+
+## Technical Details
+
+### Functional Requirement Details
+
+The `Mode::name()` method returns a `&'static str`. For Hold mode, this is the string literal `"Hold"`. The `ModeExecutor::set_mode()` logs transitions using this name:
+
+```
+Mode transition: Manual -> Hold
+Mode transition complete: Hold
+```
+
+## Platform Considerations
+
+N/A - Platform agnostic
+
+## Risks & Mitigation
+
+| Risk                                  | Impact | Likelihood | Mitigation                     | Validation |
+| ------------------------------------- | ------ | ---------- | ------------------------------ | ---------- |
+| Name mismatch with FlightMode display | Low    | Very Low   | Use conventional "Hold" string | Unit test  |
+
+## Implementation Notes
+
+- Trivial: `fn name(&self) -> &'static str { "Hold" }`
+- Tested as part of the HoldMode unit tests
+
+## External References
+
+N/A – No external references

--- a/docs/requirements/NFR-00170-hold-mode-performance.md
+++ b/docs/requirements/NFR-00170-hold-mode-performance.md
@@ -1,0 +1,73 @@
+# NFR-00170 Hold Mode Performance
+
+## Metadata
+
+- Type: Non-Functional Requirement
+- Status: Implemented
+
+## Links
+
+- Prerequisite Requirements:
+  - [FR-00168-hold-mode-actuator-stop](FR-00168-hold-mode-actuator-stop.md)
+- Dependent Requirements: N/A – no downstream requirements depend on this
+- Related Tasks:
+  - [T-00171-hold-mode](../tasks/T-00171-hold-mode/README.md)
+
+## Requirement Statement
+
+The Hold mode struct shall use no more than 32 bytes of memory and its `update()` method shall execute in constant time with no heap allocations.
+
+## Rationale
+
+Hold mode is the primary failsafe fallback. It must be:
+
+- **Lightweight**: Minimizes RAM usage on the RP2350 (264KB SRAM) to leave resources for other subsystems
+- **Deterministic**: Constant-time execution ensures predictable behavior at 50 Hz update rate
+- **Allocation-free**: No heap allocations during `update()` prevents allocation failures in low-memory failsafe scenarios
+
+## User Story
+
+The system shall ensure Hold mode has minimal resource footprint and deterministic execution, so that it remains reliable as a failsafe fallback even under resource-constrained conditions.
+
+## Acceptance Criteria
+
+- [x] `core::mem::size_of::<HoldMode>()` is ≤ 32 bytes
+- [x] `update()` performs no heap allocations (only two actuator writes)
+- [x] `update()` has no conditional branches dependent on external state (constant-time)
+
+## Technical Details
+
+### Non-Functional Requirement Details
+
+- Performance: `update()` executes 2 actuator writes per cycle (\~microsecond range)
+- Reliability: No failure path in `update()` other than actuator write errors (which are logged and propagated)
+- Compatibility: Works on all targets (RP2350 embedded, host tests, SITL)
+
+**Expected struct layout:**
+
+```
+HoldMode {
+    actuators: Box<dyn ActuatorInterface>,  // 16 bytes (fat pointer: data + vtable)
+}
+// Total: 16 bytes (well within 32-byte limit)
+```
+
+## Platform Considerations
+
+N/A - Platform agnostic
+
+## Risks & Mitigation
+
+| Risk                               | Impact | Likelihood | Mitigation                       | Validation               |
+| ---------------------------------- | ------ | ---------- | -------------------------------- | ------------------------ |
+| Future fields increase struct size | Low    | Low        | Review struct size in unit tests | `size_of` assertion test |
+
+## Implementation Notes
+
+- Add `assert!(core::mem::size_of::<HoldMode>() <= 32)` in unit tests
+- The struct only holds a `Box<dyn ActuatorInterface>` (16 bytes), well under the limit
+- No dynamic dispatch needed beyond the `ActuatorInterface` trait object already present
+
+## External References
+
+N/A – No external references

--- a/docs/tasks/T-00171-hold-mode/README.md
+++ b/docs/tasks/T-00171-hold-mode/README.md
@@ -1,0 +1,45 @@
+# T-00171 Hold Mode Implementation
+
+## Metadata
+
+- Type: Task
+- Status: Completed
+
+## Links
+
+- Related Analyses:
+  - [AN-00167-hold-mode](../../analysis/AN-00167-hold-mode.md)
+- Related Requirements:
+  - [FR-00168-hold-mode-actuator-stop](../../requirements/FR-00168-hold-mode-actuator-stop.md)
+  - [FR-00169-hold-mode-identity](../../requirements/FR-00169-hold-mode-identity.md)
+  - [NFR-00170-hold-mode-performance](../../requirements/NFR-00170-hold-mode-performance.md)
+- Related ADRs: N/A – no architectural decisions needed
+- Associated Design Document:
+  - [T-00171-hold-mode-design](design.md)
+- Associated Plan Document:
+  - [T-00171-hold-mode-plan](plan.md)
+
+## Summary
+
+Implement `HoldMode` struct in `crates/core/src/mode/hold.rs` that implements the `Mode` trait. Hold mode zeros all actuator outputs unconditionally, requires no external dependencies, and serves as the primary failsafe fallback mode.
+
+## Scope
+
+- In scope:
+  - `HoldMode` struct with `Mode` trait implementation
+  - Module registration in `crates/core/src/mode/mod.rs`
+  - Unit tests for all Mode trait methods
+  - Struct size assertion test (NFR-00170)
+  - Embedded build verification
+- Out of scope:
+  - Mode switching logic (handled by failsafe and command handler systems)
+  - Position holding (Loiter mode responsibility)
+  - ArduPilot parameters (Hold mode has none)
+  - SITL or firmware integration changes (existing dispatch already handles Hold)
+
+## Success Metrics
+
+- `HoldMode` implements `Mode` trait and passes all unit tests
+- `cargo test -p pico_trail_core --lib --quiet` passes with no failures
+- `./scripts/build-rp2350.sh pico_trail_rover` succeeds
+- `core::mem::size_of::<HoldMode>() <= 32`

--- a/docs/tasks/T-00171-hold-mode/design.md
+++ b/docs/tasks/T-00171-hold-mode/design.md
@@ -1,0 +1,151 @@
+# T-00171 Hold Mode Design
+
+## Metadata
+
+- Type: Design
+- Status: Completed
+
+## Links
+
+- Associated Plan Document:
+  - [T-00171-hold-mode-plan](plan.md)
+
+## Overview
+
+Implement `HoldMode` struct that implements the `Mode` trait with the simplest possible behavior: zero all actuator outputs. The `FlightMode::Hold` enum variant, MAVLink mapping, and `MotorControlRunner` handling already exist. This task fills the gap of a missing `Mode` trait implementation for use with `ModeExecutor`.
+
+## Success Metrics
+
+- [x] `HoldMode` struct implements `Mode` trait (enter/update/exit/name)
+- [x] All unit tests pass with no regressions
+- [x] Embedded build succeeds
+- [x] `core::mem::size_of::<HoldMode>() <= 32` bytes
+
+## Background and Current State
+
+- Context: Hold mode is the simplest control mode and the primary failsafe fallback. It must always succeed entry and produce zero motor output.
+- Current behavior: `FlightMode::Hold` enum exists at `crates/core/src/autopilot/state.rs:44`. `MotorControlRunner::step()` returns zero output for Hold at `crates/core/src/motor/runner.rs:73`. Battery failsafe uses `BatteryFailsafeAction::Hold` at `crates/core/src/autopilot/mavlink_runner.rs:77`. No `HoldMode` struct exists.
+- Pain points: Cannot use Hold mode with `ModeExecutor::set_mode()` because there is no `Mode` trait implementation.
+- Constraints: Must follow existing mode patterns (`ManualMode` as reference). Must work on embedded (RP2350) and host test targets.
+- Related ADRs: N/A
+
+## Proposed Design
+
+### High-Level Architecture
+
+```text
+ModeExecutor
+    │
+    ├── set_mode(Box<dyn Mode>)
+    │       │
+    │       ▼
+    │   HoldMode::enter()  ──► actuators.set_steering(0.0)
+    │                       ──► actuators.set_throttle(0.0)
+    │
+    ├── execute(timestamp)
+    │       │
+    │       ▼
+    │   HoldMode::update(dt) ──► actuators.set_steering(0.0)
+    │                         ──► actuators.set_throttle(0.0)
+    │
+    └── set_mode(other_mode)
+            │
+            ▼
+        HoldMode::exit()  ──► actuators.set_steering(0.0)
+                           ──► actuators.set_throttle(0.0)
+```
+
+### Components
+
+- `crates/core/src/mode/hold.rs`: New file containing `HoldMode` struct and `Mode` implementation
+- `crates/core/src/mode/mod.rs`: Add `pub mod hold;` and re-export
+
+### Data Flow
+
+1. `ModeExecutor::set_mode()` calls `HoldMode::enter()` → zeros actuators
+2. At 50 Hz, `ModeExecutor::execute()` calls `HoldMode::update(dt)` → zeros actuators
+3. On mode exit, `ModeExecutor::set_mode()` calls `HoldMode::exit()` → zeros actuators
+
+### Data Models and Types
+
+```rust
+use crate::servo::ActuatorInterface;
+use super::traits::Mode;
+
+pub struct HoldMode {
+    actuators: Box<dyn ActuatorInterface>,
+}
+```
+
+No additional types, enums, or state machines are needed.
+
+### Error Handling
+
+- `enter()`: Sets actuators to zero. Actuator write errors are propagated via `?`. No precondition checks (no GPS, RC, etc.).
+- `update()`: Propagates actuator write errors via `?`.
+- `exit()`: Propagates actuator write errors via `?`.
+- No custom error types needed; uses existing `&'static str` error pattern from `Mode` trait.
+
+### Security Considerations
+
+N/A – No network, filesystem, or user input involved.
+
+### Performance Considerations
+
+- `update()` performs exactly 2 method calls per cycle (set_steering + set_throttle)
+- No heap allocations during update
+- No conditional branches dependent on external state
+- Struct size: 16 bytes (one `Box<dyn ActuatorInterface>` fat pointer)
+
+### Platform Considerations
+
+N/A – Platform agnostic. Uses `ActuatorInterface` abstraction which has implementations for RP2350, mock (tests), and SITL.
+
+## Alternatives Considered
+
+1. Shared NullMode / StoppedMode generic
+   - Pros: Could share code if multiple modes need zero output
+   - Cons: Over-engineering; each mode has unique lifecycle; adds unnecessary abstraction
+2. No struct (keep using MotorControlRunner only)
+   - Pros: Zero implementation effort
+   - Cons: Cannot use Hold with ModeExecutor; inconsistent with other modes; blocks proper mode transition lifecycle
+
+Decision Rationale
+
+- Standalone `HoldMode` struct is the simplest approach that follows existing patterns. The implementation is \~50 lines including tests. No abstraction needed for a one-time trivial struct.
+
+## Migration and Compatibility
+
+- Backward compatible: No existing behavior changes
+- No migration needed: New file only, no modifications to existing mode behavior
+- `MotorControlRunner` continues to handle `FlightMode::Hold` as before (defense-in-depth)
+
+## Testing Strategy
+
+### Unit Tests
+
+Tests in `crates/core/src/mode/hold.rs` (inline `#[cfg(test)]` module):
+
+- `test_hold_mode_enter_exit`: Verify enter/exit succeed and actuators are zeroed
+- `test_hold_mode_update_zeros_actuators`: Verify update zeros actuators even with non-zero initial values
+- `test_hold_mode_name`: Verify `name()` returns `"Hold"`
+- `test_hold_mode_size`: Verify `size_of::<HoldMode>() <= 32`
+
+Define a local `MockActuator` in the `#[cfg(test)]` module, following the same pattern used in `manual.rs` and `auto.rs`.
+
+### Integration Tests
+
+N/A – Existing `MotorControlRunner` tests already cover `FlightMode::Hold` behavior. `ModeExecutor` tests cover mode transition lifecycle.
+
+## Documentation Impact
+
+- Update AN-00167 status and task link
+- Update FR-00168, FR-00169, NFR-00170 task links
+
+## External References
+
+- [ArduPilot Hold Mode (Rover)](https://ardupilot.org/rover/docs/hold-mode.html)
+
+## Open Questions
+
+None – all questions resolved during analysis phase.

--- a/docs/tasks/T-00171-hold-mode/plan.md
+++ b/docs/tasks/T-00171-hold-mode/plan.md
@@ -1,0 +1,137 @@
+# T-00171 Hold Mode Implementation
+
+## Metadata
+
+- Type: Implementation Plan
+- Status: Completed
+
+## Links
+
+- Associated Design Document:
+  - [T-00171-hold-mode-design](design.md)
+
+## Overview
+
+Implement `HoldMode` struct in `crates/core/src/mode/hold.rs` with `Mode` trait implementation. Single-phase task due to minimal scope.
+
+## Success Metrics
+
+- [x] `HoldMode` passes all unit tests
+- [x] `cargo test -p pico_trail_core --lib --quiet` passes
+- [x] `./scripts/build-rp2350.sh pico_trail_rover` succeeds
+- [x] `cargo clippy --all-targets -- -D warnings` passes
+- [x] All existing tests pass; no regressions in mode system
+
+## Scope
+
+- Goal: Working `HoldMode` struct with Mode trait, unit tests, and passing builds
+- Non-Goals: Mode switching integration, SITL changes, parameter additions
+- Assumptions: `MockActuator` pattern exists in `manual.rs`/`auto.rs` test modules (define locally in `hold.rs` tests)
+- Constraints: Must compile on both host (tests) and RP2350 (embedded)
+
+## ADR & Legacy Alignment
+
+- [x] No ADRs govern this work (confirmed in analysis AN-00167)
+- [x] No legacy patterns to retire (new file only)
+
+## Plan Summary
+
+- Phase 1 – HoldMode implementation, module registration, and unit tests
+
+### Phase Status Tracking
+
+Mark checkboxes (`[x]`) immediately after completing each task or subtask. If an item is intentionally skipped or deferred, annotate it (e.g., strike-through with a brief note) instead of leaving it unchecked.
+
+> **⚠ Phase Gate Rule**: After completing each phase, you MUST stop and request explicit user approval before proceeding to the next phase. Do not continue automatically.
+
+---
+
+## Phase 1: HoldMode Implementation and Tests
+
+### Goal
+
+- Create `HoldMode` struct, implement `Mode` trait, register module, add unit tests, verify all builds pass
+
+### Inputs
+
+- Documentation:
+  - `docs/tasks/T-00171-hold-mode/design.md` – Struct design and test plan
+  - `docs/analysis/AN-00167-hold-mode.md` – Analysis and raw data (implementation sketch)
+- Source Code to Modify:
+  - `crates/core/src/mode/mod.rs` – Add `pub mod hold;` and re-export
+- Source Code to Create:
+  - `crates/core/src/mode/hold.rs` – HoldMode struct and Mode impl
+- Dependencies:
+  - Internal: `crates/core/src/mode/traits.rs` – `Mode` trait
+  - Internal: `crates/core/src/servo/mod.rs` – `ActuatorInterface` trait
+  - Reference: `crates/core/src/mode/manual.rs` tests – `MockActuator` pattern to replicate
+
+### Tasks
+
+- [x] **Create HoldMode struct**
+  - [x] Create `crates/core/src/mode/hold.rs`
+  - [x] Define `HoldMode` struct with `actuators: Box<dyn ActuatorInterface>` field
+  - [x] Implement `HoldMode::new()` constructor
+  - [x] Implement `Mode` trait: `enter()`, `update()`, `exit()`, `name()`
+- [x] **Register module**
+  - [x] Add `pub mod hold;` to `crates/core/src/mode/mod.rs`
+  - [x] Add `pub use hold::HoldMode;` re-export
+- [x] **Add unit tests**
+  - [x] `test_hold_mode_enter_exit` — enter/exit succeed, actuators zeroed
+  - [x] `test_hold_mode_update_zeros_actuators` — update zeros non-zero actuators
+  - [x] `test_hold_mode_name` — name() returns "Hold"
+  - [x] `test_hold_mode_size` — size_of::\<HoldMode>() <= 32
+- [x] **Verification**
+  - [x] `cargo fmt`
+  - [x] `cargo clippy --all-targets -- -D warnings`
+  - [x] `cargo test -p pico_trail_core --lib --quiet`
+  - [x] `./scripts/build-rp2350.sh pico_trail_rover`
+- [x] **Documentation updates**
+  - [x] Update AN-00167 status
+  - [x] Update FR-00168, FR-00169, NFR-00170 Related Tasks links
+  - [x] Update this plan with checkboxes
+  - [x] Run `bun scripts/trace-status.ts --check`, `bun format`, `bun lint`
+
+### Deliverables
+
+- `crates/core/src/mode/hold.rs` — HoldMode struct + Mode impl + unit tests
+- Updated `crates/core/src/mode/mod.rs` — module registration
+
+### Verification
+
+```bash
+cargo fmt
+cargo clippy --all-targets -- -D warnings
+cargo test -p pico_trail_core --lib --quiet
+./scripts/build-rp2350.sh pico_trail_rover
+bun scripts/trace-status.ts --check
+bun format
+bun lint
+```
+
+### Acceptance Criteria (Phase Gate)
+
+- All 4 unit tests pass
+- `cargo clippy` reports no warnings
+- RP2350 embedded build succeeds
+- Traceability check passes
+
+### Rollback/Fallback
+
+- Delete `crates/core/src/mode/hold.rs` and revert `mod.rs` changes. No other files are affected by the implementation itself.
+
+---
+
+## Definition of Done
+
+- [x] Build succeeds with no errors
+- [x] Code formatted per project standards (`cargo fmt`)
+- [x] Linting passes with no warnings (`cargo clippy --all-targets -- -D warnings`)
+- [x] Unit tests pass (`cargo test -p pico_trail_core --lib --quiet`)
+- [x] Embedded build verified (`./scripts/build-rp2350.sh pico_trail_rover`)
+- [x] Documentation traceability verified (`bun scripts/trace-status.ts --check`)
+- [x] Plan checkboxes updated
+
+## Open Questions
+
+None – all questions resolved during analysis phase.


### PR DESCRIPTION
## Summary

- Add `HoldMode` struct implementing `Mode` trait that zeros all actuator outputs unconditionally
- Register module in `crates/core/src/mode/mod.rs` without embassy gate (no async dependencies)
- Include 4 unit tests: enter/exit, update zeroing, name identity, struct size assertion (≤32 bytes)

## Related

- Task: T-00171-hold-mode
- Requirements: FR-00168, FR-00169, NFR-00170
- Analysis: AN-00167

## Test plan

- [x] `cargo clippy -p pico_trail_core --all-targets -- -D warnings` passes
- [x] `cargo test -p pico_trail_core --lib --quiet` — 465 tests pass
- [x] `./scripts/build-rp2350.sh pico_trail_rover` — embedded build succeeds
- [x] `bun scripts/trace-status.ts --check` — traceability passes